### PR TITLE
Swap text layout to @chenglou/pretext

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "0.0.1",
       "dependencies": {
         "@astrojs/cloudflare": "^12.6.7",
+        "@chenglou/pretext": "^0.0.3",
         "@radix-ui/colors": "^3.0.0",
         "astro": "^5.13.5",
         "bezier-easing": "^2.1.0",
-        "canvas-text-wrapper": "^0.10.2",
         "colorjs.io": "^0.5.2",
         "google-font-metadata": "^6.0.3",
         "modern-normalize": "^3.0.1",
@@ -417,6 +417,12 @@
         "cross-fetch": "^3.0.4",
         "fontkit": "^2.0.2"
       }
+    },
+    "node_modules/@chenglou/pretext": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@chenglou/pretext/-/pretext-0.0.3.tgz",
+      "integrity": "sha512-RQmqMqUAPRCyv4R3LlRi/ao6KbNWYclqLA+V1HS7sWgyUUbjn3JmmlfXZSY/BjM4rbmIaMSyIVisYocYGYftiQ==",
+      "license": "MIT"
     },
     "node_modules/@cloudflare/kv-asset-handler": {
       "version": "0.3.4",
@@ -2693,12 +2699,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/canvas-text-wrapper": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/canvas-text-wrapper/-/canvas-text-wrapper-0.10.2.tgz",
-      "integrity": "sha512-nFnN8q8ydtkBUWVn/dAdetpwNOkz3KtyD6jTI2HGD43ant2FQcnLugAVaGLJloyRTNK/exn7efpYy2zPV5bHiQ==",
-      "license": "MIT"
     },
     "node_modules/ccount": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
   },
   "dependencies": {
     "@astrojs/cloudflare": "^12.6.7",
+    "@chenglou/pretext": "^0.0.3",
     "@radix-ui/colors": "^3.0.0",
     "astro": "^5.13.5",
     "bezier-easing": "^2.1.0",
-    "canvas-text-wrapper": "^0.10.2",
     "colorjs.io": "^0.5.2",
     "google-font-metadata": "^6.0.3",
     "modern-normalize": "^3.0.1",

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -159,7 +159,7 @@ const generateThemeHref = (theme: typeof themes[keyof typeof themes]) => {
 </style>
 
 <script>
-  import { CanvasTextWrapper } from "canvas-text-wrapper";
+  import { prepareWithSegments, layoutWithLines } from "@chenglou/pretext";
   import APIv2 from "@data/google-fonts-v2.json";
 
   const form = document.getElementById("textmojiForm") as HTMLFormElement;
@@ -197,16 +197,45 @@ const generateThemeHref = (theme: typeof themes[keyof typeof themes]) => {
     }
 
     // Draw text
+    const paddingX = 6 + (borderStyle === "all" ? 6 : 0);
+    const paddingY = 6 + (borderStyle !== "none" ? 6 : 0);
+    const maxWidth = 128 - paddingX * 2;
+    const maxHeight = 128 - paddingY * 2;
+
+    let fontSize = 128; // Start large and shrink
+    let lines: any[] = [];
+    let totalHeight = 0;
+    const fontStack = `"${fontFamily}", Inter, Roboto, 'Helvetica Neue', 'Arial Nova', 'Nimbus Sans', Arial, sans-serif`;
+
+    // Simple iterative search for the best font size
+    while (fontSize > 8) {
+      const font = `bold ${fontSize}px ${fontStack}`;
+      const prepared = prepareWithSegments(text, font);
+      const lineHeight = fontSize * 1.2;
+      const result = layoutWithLines(prepared, maxWidth, lineHeight);
+
+      if (result.height <= maxHeight) {
+        lines = result.lines;
+        totalHeight = result.height;
+        ctx.font = font;
+        break;
+      }
+      fontSize -= 2;
+    }
+
     ctx.fillStyle = textColor;
-    ctx.textRendering = "geometricPrecision";
-    CanvasTextWrapper(canvas, text, {
-      textAlign: "center",
-      verticalAlign: "middle",
-      sizeToFill: true,
-      paddingX: 6 + (borderStyle === "all" ? 6 : 0),
-      paddingY: 6 + (borderStyle !== "none" ? 6 : 0),
-      font: `bold 64px "${fontFamily}", Inter, Roboto, 'Helvetica Neue', 'Arial Nova', 'Nimbus Sans', Arial, sans-serif`,
-      renderHDPI: false,
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+
+    const startY = (128 - totalHeight) / 2;
+    const lineHeight = fontSize * 1.2;
+
+    lines.forEach((line, i) => {
+      ctx.fillText(
+        line.text,
+        128 / 2,
+        startY + i * lineHeight + lineHeight / 2
+      );
     });
 
     // Update download link


### PR DESCRIPTION
This change replaces the `canvas-text-wrapper` library with `@chenglou/pretext` for handling text layout and rendering on the canvas in `src/pages/index.astro`. The new implementation uses `pretext`'s `prepareWithSegments` and `layoutWithLines` APIs to calculate text layout and then manually draws the lines to the canvas. A "size to fill" functionality has been implemented by iteratively adjusting the font size until the text fits within the canvas boundaries. The project's dependencies have been updated accordingly, and the build process has been verified to ensure stability.

---
*PR created automatically by Jules for task [9292049851333813175](https://jules.google.com/task/9292049851333813175) started by @tylermercer*